### PR TITLE
Library linked to app

### DIFF
--- a/vite-react-app/README.md
+++ b/vite-react-app/README.md
@@ -28,3 +28,17 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+
+## Linking component library
+
+In the `vite-react-lib` run `npm pack` then `npm link`
+
+Navigate to `vite-react-app` and run `npm link <lib name>` (the name in the package.json file). In this case it's `npm link vite-react-lib`
+
+Import the components like so:
+
+`import { <component name> } from 'vite-react-lib'`
+
+Now you can use the library components in the app
+

--- a/vite-react-app/src/App.tsx
+++ b/vite-react-app/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import { Test } from 'vite-react-lib'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -24,6 +25,7 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <Test />
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more

--- a/vite-react-lib/.gitignore
+++ b/vite-react-lib/.gitignore
@@ -23,3 +23,4 @@ storybook-static
 *.njsproj
 *.sln
 *.sw?
+*.tgz

--- a/vite-react-lib/package.json
+++ b/vite-react-lib/package.json
@@ -2,7 +2,10 @@
   "name": "vite-react-lib",
   "version": "1.0.0",
   "description": "A simple react component library for vite-react-app",
-  "main": "index.ts",
+  "main": "src/index.ts",
+  "files": [
+    "src/components/**/*"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
README.md updated to instruct devs how to locally 'link' the library to the app. This is so library components can be tested in the app before being pushed to the npm registry.